### PR TITLE
Use Closure::fromCallable for runTest

### DIFF
--- a/src/AsyncTestCase.php
+++ b/src/AsyncTestCase.php
@@ -32,12 +32,10 @@ abstract class AsyncTestCase extends TestCase
      */
     protected function runTest()
     {
-        return TaskScheduler::run(function () {
-            return parent::runTest();
-        }, \Closure::fromCallable([
-            $this,
-            'debugPendingAsyncTasks'
-        ]));
+        return TaskScheduler::run(
+            \Closure::fromCallable('parent::runTest'),
+            \Closure::fromCallable([$this, 'debugPendingAsyncTasks'])
+        );
     }
 
     /**


### PR DESCRIPTION
This avoids 'AsyncTestCase' always being reported by PHPUnit in the failure log.